### PR TITLE
Adds beginnings of Slashed Zero

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "dependencies": {
     "basscss-sass": "3.0.0",
     "smoothscroll": "0.2.2",
-    "utility-opentype": "0.1.1"
+    "utility-opentype": "kennethormandy/utility-opentype#ko-zero"
   },
   "devDependencies": {
     "harp": "0.20.1",

--- a/public/index.ejs
+++ b/public/index.ejs
@@ -327,29 +327,28 @@
       </div>
       <p>The second, greyed out example shown here shows the faux subscripts the browser creates by scaling whatever you put in the <code>H&lt;sub&gt;</code> tag; by using the <code>sinf</code> class from Utility OpenType instead, you’ll use the optically correct glyphs included in your web font. In browsers that don’t support the OpenType features, the browser default will still be used.</p>
     </section>
-    <% /* <section id="zero">
+    <section id="zero">
       <h2><a href="#zero" class="font-tisa anchor speak-none select-none" aria-hidden="true">¶</a>Slashed Zero</h2>
-      // <p>TODO description paragraph</p>
+      <% /* <p>TODO description paragraph</p> */ %>
       <div class="test bg-silver rounded mb3 mt3">
         <div class="test-case overflow-hidden p1 sm-p2 md-p3 font-proxima h1 h0-responsive">
-          <div class="test-feat gray">$1,000,000</div>
-          <div class="zero">$1,000,000</div>
+          <div class="gray">$1,<span class="test-feat">0</span><span class="test-feat">0</span><span class="test-feat">0</span>,<span class="test-feat">0</span><span class="test-feat">0</span><span class="test-feat">0</span></div>
+          <div class="zero">$1,<span class="test-feat">0</span><span class="test-feat">0</span><span class="test-feat">0</span>,<span class="test-feat">0</span><span class="test-feat">0</span><span class="test-feat">0</span></div>
         </div>
         <pre class="h4 bg-navy silver p2 language-html"><code>&lt;span class=&quot;zero&quot;&gt;$1,000,000&lt;/span&gt;</code></pre>
       </div>
     </section>
     <section id="zero-onum">
       <h2><a href="#zero" class="font-tisa anchor speak-none select-none" aria-hidden="true">¶</a>Slashed, Oldstyle Zero</h2>
-      // <p>TODO description paragraph</p>
-      // This won’t work in Chrome, prob. others because `font-variant-numeric` isn’t supperted. Works in FF.
-      <div class="rounded bg-silver">
+      <% /* <p>TODO description paragraph</p> */ %>
+      <div class="test rounded bg-silver">
         <div class="test-case overflow-hidden p1 sm-p2 md-p3 font-proxima h1 h0-responsive">
-          <div class="test-feat gray">$0.01 borrowed</div>
-          <div class="zero onum">$0.01 borrowed</div>
+          <div class="gray">$<span class="test-feat">0</span>.<span class="test-feat">0</span>1 borrowed</div>
+          <div class="zero onum">$<span class="test-feat">0</span>.<span class="test-feat">0</span>1 borrowed</div>
         </div>
         <pre class="h4 bg-navy silver p2 language-html"><code>&lt;span class=&quot;zero onum&quot;&gt;$0.01 borrowed&lt;/span&gt;</code></pre>
       </div>
-    </section> */ %>
+    </section>
     <section id="request">
       <h2><a href="#request" class="font-tisa anchor speak-none select-none" aria-hidden="true">¶</a>Feature requests</h2>
       <a class="block mb3 mt3 p1 sm-p2 md-p3 rounded bg-silver black h2" href="https://github.com/kennethormandy/utility-opentype/issues">Think something is missing? Submit an issue or feature request on GitHub and <span class="purple">let’s talk about it</span>!</a>


### PR DESCRIPTION
To merge after https://github.com/kennethormandy/utility-opentype/pull/1, still needs fonts for showcase. (Using Proxima Nova right now.)

<img width="857" alt="screenshot 2015-12-12 16 51 28" src="https://cloud.githubusercontent.com/assets/1581276/11764725/9c43c82a-a0f0-11e5-8348-46aee8370fc3.png">
- [x] Update to proper version number in `package.json`
- [x] Better example
- [x] Description paragraphs
